### PR TITLE
[fix] Navigator.popUntil in WillPopCallback breaks the navigation.

### DIFF
--- a/lib/src/transition_theme.dart
+++ b/lib/src/transition_theme.dart
@@ -419,7 +419,8 @@ class _CupertinoBackGestureController<T> {
 
         Future<void>.delayed(
             const Duration(milliseconds: _kAnimateForwardDelay), () {
-          if (disposition != RoutePopDisposition.pop) {
+          if (disposition != RoutePopDisposition.pop &&
+              !controller.isAnimating) {
             _animateForward();
           }
         });


### PR DESCRIPTION
https://github.com/fluttercandies/ios_willpop_transition_theme/issues/3